### PR TITLE
added peptide_length for commandline protein strings

### DIFF
--- a/immuno/balanced_ensemble.py
+++ b/immuno/balanced_ensemble.py
@@ -69,8 +69,7 @@ class BalancedEnsembleClassifier(ClassifierMixin):
 
         n_models = 2 * int(ceil(float(n_total) / n_sub)) + 1
 
-        #print "Subsampling class sizes from (%d, %d) to %d" % \
-        #    (n_true, n_false, n_sub)
+
         for i in xrange(n_models):
 
             # subsample the true and false datasets

--- a/immuno/ensembl_annotation.py
+++ b/immuno/ensembl_annotation.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.    
+# limitations under the License.
 
 import pandas as pd
 
@@ -21,7 +21,7 @@ TRANSCRIPT_META_DATA_FILE = download_transcript_metadata()
 EXON_DATA = pd.read_csv(TRANSCRIPT_META_DATA_FILE, sep='\t')
 
 # Subset columns for transcript data only
-TRANSCRIPT_DATA = EXON_DATA[['name', 'stable_id_gene', 'description_gene', 'seq_region_start_gene', 'seq_region_end_gene', 'stable_id_transcript', 
+TRANSCRIPT_DATA = EXON_DATA[['name', 'stable_id_gene', 'description_gene', 'seq_region_start_gene', 'seq_region_end_gene', 'stable_id_transcript',
                 'seq_region_start_transcript', 'seq_region_end_transcript']].drop_duplicates()
 
 # Subset columns for gene data only
@@ -90,7 +90,8 @@ def get_exons_from_transcript(transcript_id):
     returns Pandas dataframe containing only those exons
     """
     exons = EXON_DATA[EXON_DATA['stable_id_transcript'] == transcript_id]
-    return exons[['stable_id_exon', 'seq_region_start_exon', 'seq_region_end_exon']]
+    fields = ['stable_id_exon', 'seq_region_start_exon', 'seq_region_end_exon']
+    return exons[fields]
 
 def get_transcript_index_from_pos(pos, transcript_id):
     """ gets the index into to the transcript from genomic position
@@ -103,9 +104,11 @@ def get_transcript_index_from_pos(pos, transcript_id):
     position : int, genomic position in the contig
     transcript_id : transcript id, of the from EST#####
 
-    returns 
+    returns
     """
-    exons = get_exons_from_transcript(transcript_id).sort(columns=['seq_region_start_exon', 'seq_region_end_exon'])
+    exons = get_exons_from_transcript(transcript_id)
+    exons = exons.sort(columns=['seq_region_start_exon', 'seq_region_end_exon'])
+
     transcript_idx = 0
     for (idx, row) in exons.iterrows():
         if pos > row['seq_region_end_exon']:

--- a/immuno/ensembl_io.py
+++ b/immuno/ensembl_io.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License. 
+# limitations under the License.
 
 from os.path import join, exists
 from os import environ
@@ -25,11 +25,11 @@ STANDARD_CONTIGS = set(['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11',
                        '19', '20', '21', '22', 'X', 'Y', 'M'])
 
 
-GENE_HEADER = [ 'gene_id', 'biotype', 'analysis_id', 
-        'seq_region_id', 'seq_region_start', 'seq_region_end', 
-        'seq_region_strand', 'display_xref_id', 
-        'source', 'status', 'description', 'is_current', 
-        'canonical_transcript_id', 'stable_id', 
+GENE_HEADER = [ 'gene_id', 'biotype', 'analysis_id',
+        'seq_region_id', 'seq_region_start', 'seq_region_end',
+        'seq_region_strand', 'display_xref_id',
+        'source', 'status', 'description', 'is_current',
+        'canonical_transcript_id', 'stable_id',
         'version', 'created_date', 'modified_date']
 
 SEQ_REGION_HEADER = ['seq_region_id', 'name', 'coord_system_id']
@@ -55,7 +55,6 @@ def download_transcript_metadata(output_file = 'gene_exon_transcript.tsv', filte
         TRANSCRIPT_DATA_PATH = fetch_data('transcript.txt', "ftp://ftp.ensembl.org/pub/release-74/mysql/homo_sapiens_core_74_37/transcript.txt.gz")
         EXON_TRANSCRIPT_DATA_PATH = fetch_data('exon_transcript.txt', "ftp://ftp.ensembl.org/pub/release-74/mysql/homo_sapiens_core_74_37/exon_transcript.txt.gz")
 
-
         seqregion = pd.read_csv(SEQ_REGION_DATA_PATH, sep='\t', names = SEQ_REGION_HEADER, index_col=False)
         if filter_contigs:
             seqregion = seqregion[ seqregion['name'].map(lambda x: x in filter_contigs)]
@@ -71,7 +70,7 @@ def download_transcript_metadata(output_file = 'gene_exon_transcript.tsv', filte
         exon_w_exon_transcript = pd.merge(exon, exon_transcript, on='exon_id', suffixes=('_exon', '_et'))
 
         exon_w_transcript = pd.merge(exon_w_exon_transcript, gene_transcript, on='transcript_id', suffixes=('_exon', '_transcript'))
-        exon_data = exon_w_transcript[['name', 'stable_id_gene', 'description_gene', 'seq_region_start_gene', 'seq_region_end_gene', 'stable_id_transcript', 
+        exon_data = exon_w_transcript[['name', 'stable_id_gene', 'description_gene', 'seq_region_start_gene', 'seq_region_end_gene', 'stable_id_transcript',
                         'seq_region_start_transcript', 'seq_region_end_transcript', 'stable_id_exon', 'seq_region_start_exon', 'seq_region_end_exon']]
 
         exon_data.to_csv(full_path, index=False, sep='\t')
@@ -81,7 +80,7 @@ def download_transcript_metadata(output_file = 'gene_exon_transcript.tsv', filte
 def download_protein_transcripts():
     path = fetch_data('Homo_sapiens.GRCh37.74.pep.all.fa.gz', 'ftp://ftp.ensembl.org/pub/release-74/fasta/homo_sapiens/pep/Homo_sapiens.GRCh37.74.pep.all.fa.gz')
     return path
-    
+
 def download_cdna_transcripts():
     path = fetch_data('Homo_sapiens.GRCh37.74.cdna.all.fa.gz', 'ftp://ftp.ensembl.org/pub/release-74/fasta/homo_sapiens/cdna/Homo_sapiens.GRCh37.74.cdna.all.fa.gz')
     return path

--- a/immuno/immunogenicity.py
+++ b/immuno/immunogenicity.py
@@ -32,13 +32,14 @@ def train():
         assay_group = 'cytotoxicity',
         human = True,
         mhc_class = 1,
-        max_ngram = 3,
-        reduced_alphabet = reduced_alphabet.hp2,
+        max_ngram = 2,
+        reduced_alphabet = reduced_alphabet.sdm12,
         min_count = None,
         return_transformer = True)
     ensemble = BalancedEnsembleClassifier()
     ensemble.fit(X, Y)
     return vectorizer, ensemble
+
 
 def train_cached(
         model_filename = 'immunogenicity_classifier.pickle',
@@ -88,9 +89,4 @@ class ImmunogenicityRFModel(PipelineElement):
             X = self.vectorizer.transform(df.peptide)
         else:
             X = df.peptide
-        res = self.classifier.decision_function(X)
-        print res
-        print self.classifier.predict(X)
-        print self.classifier.predict_proba(X)
-        print self.classifier._predict_counts(X)
-        return res
+        return self.classifier.decision_function(X)


### PR DESCRIPTION
For protein strings given as a commandline argument you can now specify "--peptide_length" for how long the vaccine peptides will be. Not yet implemented: aggregation at the end of the pipeline (grouping by peptides), switch the currently misnamed Epitope and Peptide columns, use peptide_length argument for input files.
