### PR TITLE
Changing requires to install_requires, as that's the setuptools argument

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,12 @@ if __name__ == '__main__':
         ],
         install_requires=[
             'numpy>=1.7',
+            'scipy',
             'pandas>=0.13.1',
             'scikit-learn>=0.14.1',
             'biopython',
             'dsltools',
+            'mako',
             'datacache',
             'epitopes',
         ],


### PR DESCRIPTION
Also switching scitkit.learn to its pypi name (scikit_learn), and removing parentheses that aren't proper install_requires format.
