### PR TITLE
Setting the Biomart query to Ensembl 75

### DIFF
--- a/immuno/ensembl/gene_names.py
+++ b/immuno/ensembl/gene_names.py
@@ -54,7 +54,7 @@ _BIOMART_QUERY = \
 </Query>
 """.replace("\n", "")
 _BIOMART_URL = \
-	"http://www.biomart.org/biomart/martservice/result?query=%s" % \
+	"http://feb2014.archive.ensembl.org/biomart/martservice/result?query=%s" % \
 	_BIOMART_QUERY
 
 def transcript_id_to_gene_id(transcript_id, _table_cache = [None]):

--- a/test/test_load_tcga_data.py
+++ b/test/test_load_tcga_data.py
@@ -19,5 +19,5 @@ def test_load_tcga_skcm():
     assert len(transcripts_df) > 0
 
 if __name__ == '__main__':
-  from dsltools import testing_helpers
-  testing_helpers.run_local_tests()
+    from dsltools import testing_helpers
+    testing_helpers.run_local_tests()


### PR DESCRIPTION
The Biomart query was not in line with Ensembl 75, so the transcripts didn't line up with the rest of the data. (Changing test data values didn't help.)

It took me a while to figure out that it was possible to query the Biomart archive.
